### PR TITLE
Update german localization and fix spelling in english localization

### DIFF
--- a/localization/de.lua
+++ b/localization/de.lua
@@ -64,4 +64,4 @@ L.TipDelimiter = '|'
 --databroker plugin tooltips
 L.TipShowBank = '<Rechtsklick> um die Bank umzuschalten'
 L.TipShowInventory = '<Klicken> um das Inventar umzuschalten'
-L.TipShowOptions = '<Schift-Klick> um das Konfigurationsmen\195\188 anzuzeigen'
+L.TipShowOptions = '<Shift-Klick> um das Konfigurationsmen\195\188 anzuzeigen'

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -9,7 +9,8 @@ if not L then return end
 --keybinding text
 L.ToggleBags = 'Inventar umschalten'
 L.ToggleBank = 'Bank umschalten'
-L.ToggleKeys = 'Schl\195\188sselbund umschalten'
+L.ToggleGuild = 'Gildenbank umschalten'
+L.ToggleVault = 'Leerenlager umschalten'
 
 
 --system messages
@@ -19,48 +20,48 @@ L.UpdatedIncompatible = 'Aktualisierung von einer inkompatiblen Version. Standar
 
 
 --slash commands
-L.Commands = 'Befehle:'
-L.CmdShowInventory = 'Schaltet die Inventaranzeige um'
-L.CmdShowBank = 'Schaltet die Bankanzeige um'
+L.Commands = 'Befehlsliste'
+L.CmdShowInventory = 'Schaltet das Inventar um'
+L.CmdShowBank = 'Schaltet die Bank um'
+L.CmdShowGuild = 'Schaltet die Gildenbank um'
+L.CmdShowVault = 'Schaltet das Leerenlager um'
 L.CmdShowVersion = 'Zeigt die aktuelle Version an'
 
 
 --frame text
-L.TitleBags = '%s\'s Inventar'
-L.TitleBank = '%s\'s Bank'
+L.TitleBags = 'Inventar von %s'
+L.TitleBank = 'Bank von %s'
 
 
 --tooltips
-L.TitleBags = 'Inventar von %s'
-L.TitleBank = 'Bank von %s'
-L.TipBankToggle = '<Rechts-Klick> um die Bank umzuschalten.'
+L.TipBags = 'Taschen'
 L.TipChangePlayer = '<Klicken> um die Gegenst\195\164nde anderer Charaktere anzuzeigen.'
+L.TipCleanBags = '<Klicken> um die Taschen aufräumen.'
+L.TipCleanBank = '<Klicken> um die Bank aufzuräumen.'
+L.TipDepositReagents = '<Rechtsklick> um alle Reagenzien einzulagern.'
+L.TipFrameToggle = '<Rechtsklick> um andere Fenster umzuschalten.'
 L.TipGoldOnRealm = 'Auf %s gesamt'
 L.TipHideBag = '<Klicken> um diese Tasche zu verstecken.'
 L.TipHideBags = '<Klicken> um die Taschenanzeige zu verstecken.'
 L.TipHideSearch = '<Klicken> um das Suchfenster zu verstecken.'
-L.TipInventoryToggle = '<Rechts-Klick> um das Inventar umzuschalten.'
+L.TipManageBank = 'Bank verwalten'
 L.PurchaseBag = '<Klicken> um das Bankfach zu kaufen.'
-L.TipShowBag = '<Klicken> um diese Tasche anzuzeigen.'
+L.TipShowBag = '<Klicken> um diese Taschen anzuzeigen.'
 L.TipShowBags = '<Klicken> um das Taschenfenster anzuzeigen.'
 L.TipShowMenu = '<Rechtsklick> um das Fenster zu konfigurieren.'
 L.TipShowSearch = '<Klicken> zum Suchen.'
-L.TipShowFrameConfig = '<Klick> um dieses Fenster zu konfigurieren.'
+L.TipShowFrameConfig = '<Klicken> um dieses Fenster zu konfigurieren.'
 L.TipDoubleClickSearch = '<Alt-Ziehen> zum Verschieben.\n<Rechtsklick> zum Konfigurieren.\n<Doppelklick> zum Suchen.'
 L.Total = 'Gesamt'
-L.TipCleanBags = '<Klicken> um die Taschen aufräumen.'
-L.TipCleanBank = '<Rechtsklicken> um die Bank aufzuräumen.'
-L.TipDepositReagents = '<Linksklicken> um alle Reagenzien einzulagern.'
-L.TipFrameToggle = '<Rechtsclick> um andere Fenster umzuschalten.'
-L.TipManageBank = 'Bank verwalten'
-L.TipCount4 = 'Leerenlager: %d'
 
 --itemcount tooltips
 L.TipCount1 = 'Angelegt: %d'
 L.TipCount2 = 'Taschen: %d'
 L.TipCount3 = 'Bank: %d'
+L.TipCount4 = 'Leerenlager: %d'
+L.TipDelimiter = '|'
 
 --databroker plugin tooltips
-L.TipShowBank = '<Umschalt-Linksklick> um die Bank umzuschalten'
-L.TipShowInventory = '<Linksklick> um das Inventar umzuschalten'
-L.TipShowOptions = '<Rechtsklick> um das Konfigurationsmen\195\188 anzuzeigen'
+L.TipShowBank = '<Rechtsklick> um die Bank umzuschalten'
+L.TipShowInventory = '<Klicken> um das Inventar umzuschalten'
+L.TipShowOptions = '<Schift-Klick> um das Konfigurationsmen\195\188 anzuzeigen'

--- a/localization/en.lua
+++ b/localization/en.lua
@@ -24,7 +24,7 @@ L.CmdShowInventory = 'Toggles your inventory'
 L.CmdShowBank = 'Toggles your bank'
 L.CmdShowGuild = 'Toggles your guild bank'
 L.CmdShowVault = 'Toggles your void storage'
-L.CmdShowVersion = 'Prints the current verison'
+L.CmdShowVersion = 'Prints the current version'
 
 
 --frame text


### PR DESCRIPTION
Updates all the localization strings. Fixes #353 from tullamods/Bagnon (https://github.com/tullamods/Bagnon/issues/353) for german localization.
