### PR TITLE
Add option to auto-reset to current player

### DIFF
--- a/core/classes.lua
+++ b/core/classes.lua
@@ -33,7 +33,23 @@ function Addon:NewClass(name, type, parent)
 		end
 
 		class.IsCached = function(self)
-			return self:GetFrame():IsCached()
+			local frame = self:GetFrame()
+			return frame and frame:IsCached()
+			-- ^ Workaround/hack to address a bug.
+			-- Steps to reproduce the bug with 100% reliability:
+			--
+			-- 1. Open the bag frame
+			-- 2. Select another character with more total bag slots than the current character
+			-- 3. Close the bag frame
+			--    3a. ...by pressing the Escape key in an unmodified Bagnon
+			--    3b. ...or by any means with the "auto reset player" modification (this fork/branch by Phanx)
+			-- 4. Open the bag frame
+			-- 5. Error overload
+			--
+			-- I (Phanx) have neither the time nor the interest to pore over thousands
+			-- of lines of unfamiliar code to track down exactly why this happens and
+			-- figure out a more "proper" fix, but this hack stops the errors and seems
+			-- to have no undesirable side effects, so here it is.
 		end
 
 		class.GetProfile = function(self)
@@ -41,7 +57,9 @@ function Addon:NewClass(name, type, parent)
 		end
 
 		class.GetPlayer = function(self)
-			return self:GetFrame():GetPlayer()
+			local frame = self:GetFrame()
+			return frame and frame:GetPlayer()
+			-- ^ See notes in 'IsCached' method above.
 		end
 
 		class.GetFrameID = function(self)

--- a/core/events.lua
+++ b/core/events.lua
@@ -51,6 +51,11 @@ function Events:REAGENTBANK_PURCHASED()
 end
 
 function Events:BANKFRAME_OPENED()
+	-- Always reset to current character when interacting with a banker NPC
+	if Addon:GetFrame('bank') then
+		Addon:GetFrame('bank'):SetPlayer(nil)
+	end
+
 	if self.firstVisit then
 		self.firstVisit = nil
 		self:UpdateSize(BANK_CONTAINER)


### PR DESCRIPTION
This is one of a four-part pull request (Bagnon, Bagnon_Config, Bagnon_VoidStorage, and Wildpants) that does the following:
1. Adds an option to automatically reset to the current player when closing and reopening any window.
2. Always resets the bank and void storage windows to the current player when clicking on a bank or void storage NPC.

This specific pull request also includes a hack-ish workaround for https://github.com/tullamods/Bagnon/issues/417

See also:
- https://github.com/tullamods/Bagnon/pull/418
- https://github.com/tullamods/Bagnon_Config/pull/11
- https://github.com/Jaliborc/Bagnon_VoidStorage/pull/1
