### PR TITLE
Add option for Empty on Top

### DIFF
--- a/config/panels.lua
+++ b/config/panels.lua
@@ -101,6 +101,7 @@ Addon.FrameOptions = Addon.Options:NewPanel(ADDON, L.FrameSettings, L.FrameSetti
 			row:CreateCheck('reverseBags')
 			row:CreateCheck('reverseSlots')
 			row:CreateCheck('bagBreak')
+			row:CreateCheck('emptyOnTop')
 
 			if REAGENTBANK_CONTAINER and self.frameID == 'bank' then
 				row:CreateCheck('exclusiveReagent')

--- a/localization/config/en.lua
+++ b/localization/config/en.lua
@@ -48,6 +48,7 @@ L.Layer = 'Layer'
 L.BagBreak = 'Bag Break'
 L.ReverseBags = 'Reverse Bag Order'
 L.ReverseSlots = 'Reverse Slot Order'
+L.EmptyOnTop = 'Empty Slots On Top'
 
 L.Color = 'Background Color'
 L.BorderColor = 'Border Color'


### PR DESCRIPTION
When the bag slots aren't an even factor of the column count, this adds a toggle to put the empty spots at the top of the items instead of at the end.

(I only added the language for the english localization)