### PR TITLE
Collect BAG_UPDATE events to improve performance

### DIFF
--- a/api/events.lua
+++ b/api/events.lua
@@ -29,6 +29,7 @@ function Events:OnEnable()
 	end
 
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_CLOSED', 'BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE_DELAYED')
 	self:RegisterEvent('PLAYERBANKSLOTS_CHANGED')
 	self:RegisterMessage('CACHE_BANK_OPENED')

--- a/classes/bag.lua
+++ b/classes/bag.lua
@@ -119,6 +119,8 @@ end
 
 --[[ Events ]]--
 
+Bag.flaggedBags = {}
+
 function Bag:RegisterEvents()
 	self:Update()
 
@@ -127,6 +129,7 @@ function Bag:RegisterEvents()
 	self:RegisterFrameSignal('FILTERS_CHANGED', 'UpdateToggle')
 	self:RegisterEvent('BAG_CLOSED', 'BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_UPDATE_DELAYED')
 
 	if self:IsBank() or self:IsBankBag() or self:IsReagents() then
 		self:RegisterMessage('CACHE_BANK_OPENED', 'RegisterEvents')
@@ -146,9 +149,17 @@ function Bag:RegisterEvents()
 end
 
 function Bag:BAG_UPDATE(_, bag)
-	if bag == self:GetSlot() then
-		self:Update()
+	self.flaggedBags[bag] = true
+end
+
+function Bag:BAG_UPDATE_DELAYED ()
+	for bag in pairs(self.flaggedBags) do
+		if bag == self:GetSlot() then
+			self:Update()
+		end
 	end
+
+	self.flaggedBags = {}
 end
 
 

--- a/features/tooltipCounts.lua
+++ b/features/tooltipCounts.lua
@@ -76,24 +76,37 @@ local function AddOwners(tooltip, link)
 			text = ItemText[owner][itemID]
 		else
 			if not info.isguild then
-				local equip = FindItemCount(owner, 'equip', itemID)
-				local vault = FindItemCount(owner, 'vault', itemID)
+				local equip
+				local vault
 				local bags, bank = 0,0
 
+				if (Addon.GetItemCount) then
+					equip = Addon:GetItemCount(owner, 'equip', itemID)
+					vault = Addon:GetItemCount(owner, 'vault', itemID)
+				else
+					equip = FindItemCount(owner, 'equip', itemID)
+					vault = FindItemCount(owner, 'vault', itemID)
+				end
+
 				if info.cached then
-					for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
-						bags = bags + FindItemCount(owner, i, itemID)
-					end
+					if (Addon.GetItemCount) then
+						bags = Addon:GetItemCount(owner, 'bags', itemID)
+						bank = Addon:GetItemCount(owner, 'bank', itemID)
+					else
+						for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
+							bags = bags + FindItemCount(owner, i, itemID)
+						end
 
-					for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
-						bank = bank + FindItemCount(owner, i, itemID)
-					end
+						for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
+							bank = bank + FindItemCount(owner, i, itemID)
+						end
 
-					if REAGENTBANK_CONTAINER then
-						bank = bank + FindItemCount(owner, REAGENTBANK_CONTAINER, itemID)
-					end
+						if REAGENTBANK_CONTAINER then
+							bank = bank + FindItemCount(owner, REAGENTBANK_CONTAINER, itemID)
+						end
 
-					bank = bank + FindItemCount(owner, BANK_CONTAINER, itemID)
+						bank = bank + FindItemCount(owner, BANK_CONTAINER, itemID)
+					end
 				else
 					local owned = GetItemCount(itemID, true)
 					local carrying = GetItemCount(itemID)
@@ -179,7 +192,7 @@ function TooltipCounts:OnEnable()
 	if Addon.sets.tipCount then
 		if not ItemText then
 			ItemText, ItemCount = {}, {}
-			
+
 			HookTip(GameTooltip)
 			HookTip(ItemRefTooltip)
 		end


### PR DESCRIPTION
When moving items inside a bag, the BAG_UPDATE event fires at least 2 times for that bag.
By collecting these events and only updating once, bags don't get updated multiple times needlessly.
Also, the setting of the size or type of all bags on every BAG_UPDATE seemed to have an impact on performance and is now done only once for the bags that were updated.
With this change and the change in my merge request for BagBrother, all lag spikes I previously had when looting something with open bags are gone.