### PR TITLE
Use GetItemCount API for determining item counts if available

### DIFF
--- a/features/tooltipCounts.lua
+++ b/features/tooltipCounts.lua
@@ -76,24 +76,37 @@ local function AddOwners(tooltip, link)
 			text = ItemText[owner][itemID]
 		else
 			if not info.isguild then
-				local equip = FindItemCount(owner, 'equip', itemID)
-				local vault = FindItemCount(owner, 'vault', itemID)
+				local equip
+				local vault
 				local bags, bank = 0,0
 
+				if (Addon.GetItemCount) then
+					equip = Addon:GetItemCount(owner, 'equip', itemID)
+					vault = Addon:GetItemCount(owner, 'vault', itemID)
+				else
+					equip = FindItemCount(owner, 'equip', itemID)
+					vault = FindItemCount(owner, 'vault', itemID)
+				end
+
 				if info.cached then
-					for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
-						bags = bags + FindItemCount(owner, i, itemID)
-					end
+					if (Addon.GetItemCount) then
+						bags = Addon:GetItemCount(owner, 'bags', itemID)
+						bank = Addon:GetItemCount(owner, 'bank', itemID)
+					else
+						for i = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
+							bags = bags + FindItemCount(owner, i, itemID)
+						end
 
-					for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
-						bank = bank + FindItemCount(owner, i, itemID)
-					end
+						for i = FIRST_BANK_SLOT, LAST_BANK_SLOT do
+							bank = bank + FindItemCount(owner, i, itemID)
+						end
 
-					if REAGENTBANK_CONTAINER then
-						bank = bank + FindItemCount(owner, REAGENTBANK_CONTAINER, itemID)
-					end
+						if REAGENTBANK_CONTAINER then
+							bank = bank + FindItemCount(owner, REAGENTBANK_CONTAINER, itemID)
+						end
 
-					bank = bank + FindItemCount(owner, BANK_CONTAINER, itemID)
+						bank = bank + FindItemCount(owner, BANK_CONTAINER, itemID)
+					end
 				else
 					local owned = GetItemCount(itemID, true)
 					local carrying = GetItemCount(itemID)
@@ -179,7 +192,7 @@ function TooltipCounts:OnEnable()
 	if Addon.sets.tipCount then
 		if not ItemText then
 			ItemText, ItemCount = {}, {}
-			
+
 			HookTip(GameTooltip)
 			HookTip(ItemRefTooltip)
 		end


### PR DESCRIPTION
With this change, Wildpants will make use of the new API from these pull requests: [BagBrother](https://github.com/Jaliborc/BagBrother/pull/7) [LibItemCache-2.0](https://github.com/Jaliborc/LibItemCache-2.0/pull/14).
With this API, Tooltips in Bagnon/Combuctor will no longer cause lag spikes due to recalculating item counts over and over.