### PR TITLE
Use corrupted item overlay

### DIFF
--- a/classes/item.lua
+++ b/classes/item.lua
@@ -216,7 +216,7 @@ end
 --[[ Appearance ]]--
 
 function Item:UpdateBorder()
-	local id, quality = self.info.id, self.info.quality
+	local id, quality, link = self.info.id, self.info.quality, self.info.link
 	local new = Addon.sets.glowNew and self:IsNew()
 	local quest, questID = self:IsQuestItem()
 	local paid = self:IsPaid()
@@ -249,7 +249,14 @@ function Item:UpdateBorder()
 	self.NewItemTexture:SetAtlas(quality and NEW_ITEM_ATLAS_BY_QUALITY[quality] or 'bags-glow-white')
 	self.NewItemTexture:SetShown(new and not paid)
 
-	self.IconOverlay:SetShown(id and C_AzeriteEmpoweredItem and C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItemByID(id))
+	if id then
+		if link and IsCorruptedItem(link) then
+			self.IconOverlay:SetAtlas('Nzoth-inventory-icon')
+		end
+	end
+
+	self.IconOverlay:SetShown(id and C_AzeriteEmpoweredItem and C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItemByID(id) or link and IsCorruptedItem(link))
+
 	self.JunkIcon:SetShown(Addon.sets.glowPoor and quality == LE_ITEM_QUALITY_POOR and not self.info.worthless)
 	self.BattlepayItemTexture:SetShown(new and paid)
 	self.QuestBorder:SetShown(questID)


### PR DESCRIPTION
The issue is that default UI shows corrupted eye on top left corner of the item. It is handy, so I've added this overlay. Hope you'll merge it soon. And if you do can you please update Bagnon repository with bumped up submodule dependency please?