### PR TITLE
Improve performance by collecting BAG_UPDATE events

### DIFF
--- a/api/events.lua
+++ b/api/events.lua
@@ -29,6 +29,7 @@ function Events:OnEnable()
 	end
 
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_CLOSED', 'BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE_DELAYED')
 	self:RegisterEvent('PLAYERBANKSLOTS_CHANGED')
 	self:RegisterMessage('CACHE_BANK_OPENED')

--- a/classes/bag.lua
+++ b/classes/bag.lua
@@ -119,6 +119,8 @@ end
 
 --[[ Events ]]--
 
+Bag.flaggedBags = {}
+
 function Bag:RegisterEvents()
 	self:Update()
 
@@ -127,6 +129,7 @@ function Bag:RegisterEvents()
 	self:RegisterFrameSignal('FILTERS_CHANGED', 'UpdateToggle')
 	self:RegisterEvent('BAG_CLOSED', 'BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE')
+	self:RegisterEvent('BAG_UPDATE_DELAYED')
 
 	if self:IsBank() or self:IsBankBag() or self:IsReagents() then
 		self:RegisterMessage('CACHE_BANK_OPENED', 'RegisterEvents')
@@ -146,9 +149,17 @@ function Bag:RegisterEvents()
 end
 
 function Bag:BAG_UPDATE(_, bag)
-	if bag == self:GetSlot() then
-		self:Update()
+	self.flaggedBags[bag] = true
+end
+
+function Bag:BAG_UPDATE_DELAYED ()
+	for bag in pairs(self.flaggedBags) do
+		if bag == self:GetSlot() then
+			self:Update()
+		end
 	end
+
+	self.flaggedBags = {}
 end
 
 


### PR DESCRIPTION
When moving items inside a bag, the BAG_UPDATE event fires at least 2 times for that bag.
By collecting these events and only updating once, bags don't get updated multiple times needlessly.
Also, the setting of the size or type of all bags on every BAG_UPDATE seemed to have an impact on performance and is now done only once for the bags that were updated.
With this change and the change in my merge request for BagBrother, all lag spikes I previously had when looting something with open bags are gone.