### PR TITLE
TBC Fixed key sorting issue

### DIFF
--- a/api/sorting.lua
+++ b/api/sorting.lua
@@ -45,6 +45,10 @@ function Sort:Iterate()
   local stackable = function(item)
     return (item.count or 1) < (item.stack or 1)
   end
+	
+	local iskey = function(item)
+		return string.find(item.name, "Key")
+	end
 
   for k, target in pairs(spaces) do
     local item = target.item
@@ -53,7 +57,7 @@ function Sort:Iterate()
         local from = spaces[j]
         local other = from.item
 
-        if item.id == other.id and stackable(other) then
+        if item.id == other.id and stackable(other) and not iskey(item) then
           self:Move(from, target)
           self:Delay(0.05, 'Run')
         end
@@ -71,7 +75,7 @@ function Sort:Iterate()
 
     for index = 1, n do
       local item, goal = order[index], spaces[index]
-      if item.space ~= goal then
+      if item.space ~= goal and not iskey(item) then
         local distance = moveDistance(item, goal)
 
         for j = index, n do


### PR DESCRIPTION
Since TBC prepatch, bagnon's sorting feature is broken if certain keys are in player's key ring.

Though this can be resolved by putting the problematic keys into the bank, we should have a fix for the addon itself.

This is a simple fix that resolves the issue.