### PR TITLE
Fix infinite sort issue by separating keyring family check

### DIFF
--- a/api/sorting.lua
+++ b/api/sorting.lua
@@ -165,10 +165,12 @@ function Sort:CanRun()
 end
 
 function Sort:FitsIn(id, family)
-  return
-    family == 0 or
-    (family == 9 and GetItemFamily(id) == 256) or
-    (bit.band(GetItemFamily(id), family) > 0 and select(9, GetItemInfo(id)) ~= 'INVTYPE_BAG')
+   -- Is the target family the key ring?
+  if family == 9 then
+    return GetItemFamily(id) == 256
+  end
+  
+  return family == 0 or (bit.band(GetItemFamily(id), family) > 0 and select(9, GetItemInfo(id)) ~= 'INVTYPE_BAG')
 end
 
 function Sort.Rule(a, b)


### PR DESCRIPTION
The issue here is that the family of the keyring is 9, which is 1001 in binary. Some items have a family with value 8, which is 1000. Therefore the last line which does a binary AND between both values succeeds for items that shouldn't go into the keyring.

The fix here is to just separate the check for the keyring. Keyring items should only be items where GetItemFamily(id) == 256