### PR TITLE
fixes the infinite sorting issue caused by the keyring

### DIFF
--- a/api/sorting.lua
+++ b/api/sorting.lua
@@ -165,10 +165,12 @@ function Sort:CanRun()
 end
 
 function Sort:FitsIn(id, family)
-  return
-    family == 0 or
-    (family == 9 and GetItemFamily(id) == 256) or
-    (bit.band(GetItemFamily(id), family) > 0 and select(9, GetItemInfo(id)) ~= 'INVTYPE_BAG')
+   -- Is the target family the key ring?
+  if family == 9 then
+    return GetItemFamily(id) == 256
+  end
+  
+  return family == 0 or (bit.band(GetItemFamily(id), family) > 0 and select(9, GetItemInfo(id)) ~= 'INVTYPE_BAG')
 end
 
 function Sort.Rule(a, b)


### PR DESCRIPTION
Fixes the issue where bagnon attempts to put an item in the keyring. 
The keyring's family is 9 (1001 in binary). Some items have a family value of 8 (1000 in binary). Therefore, the last line in the check succeeds when AND-ing 9 and 8 and incorrectly attempts to fit an item into the keyring. 

This fix separates the keyring condition and isolates it, so that only items with GetItemFamily(id) == 256 succeed. 