### PR TITLE
Fix to show upgrade icon from Pawn in bags

### DIFF
--- a/classes/item.lua
+++ b/classes/item.lua
@@ -436,10 +436,15 @@ function Item:IsQuestItem()
 end
 
 function Item:IsUpgrade()
-	local criteria = PawnIsContainerItemAnUpgrade or IsContainerItemAnUpgrade
-	if criteria then -- difference bettween nil and false
-		return criteria(self:GetBag(), self:GetID())
+	if not PawnShouldItemLinkHaveUpgradeArrow then
+		return false
 	end
+
+	local _, Count, _, _, _, _, ItemLink = GetContainerItemInfo(self:GetBag(), self:GetID())
+	if not Count then return false end
+	if not ItemLink then return nil end
+
+	return PawnShouldItemLinkHaveUpgradeArrow(ItemLink, true)
 end
 
 function Item:IsNew()


### PR DESCRIPTION
## What happened

Update `Item:IsUpgrade()` to make it work and show upgrade icon from Pawn

## Proof Of Work

![Screen Shot 2021-11-23 at 15 11 05](https://user-images.githubusercontent.com/17875522/142989404-5f8b476d-a959-42ba-ade4-9a3346deae4b.png)

