### PR TITLE
Update bag.lua

### DIFF
--- a/classes/bag.lua
+++ b/classes/bag.lua
@@ -141,7 +141,7 @@ function Bag:RegisterEvents()
 			end
 
 			self:RegisterEvent('ITEM_LOCK_CHANGED', 'UpdateLock')
-			self:RegisterEvent('CURSOR_UPDATE', 'UpdateCursor')
+			self:RegisterEvent('CURSOR_CHANGED', 'UpdateCursor')
 		end
 	elseif self:IsCustomSlot() then
 		self:RegisterEvent('GET_ITEM_INFO_RECEIVED', 'Update')


### PR DESCRIPTION
Currently in WotLK Classic Beta and PTR there is no even CURSOR_UPDATE as I believe it may have been renamed to CURSOR_CHANGED. This change fixes that and it all appears to work normally but I can't be certain!