### PR TITLE
Fixed Pawn-Arrow not showing

### DIFF
--- a/classes/item.lua
+++ b/classes/item.lua
@@ -436,9 +436,11 @@ function Item:IsQuestItem()
 end
 
 function Item:IsUpgrade()
-	local criteria = PawnIsContainerItemAnUpgrade or IsContainerItemAnUpgrade
+	local criteria = PawnShouldItemLinkHaveUpgradeArrow
 	if criteria then -- difference bettween nil and false
-		return criteria(self:GetBag(), self:GetID())
+		if self:GetItem() then
+			return criteria(self:GetItem(), true)
+		end
 	end
 end
 


### PR DESCRIPTION
This is my implementation of fixing the currently broken (In Classic) feature where an arrow from Pawn would be displayed in Bagnon.

Changed the criteria from Pawns "Is this an upgrade" to Pawns "Should this idem have a upgrade-arrow" which is more exact.