### PR TITLE
Fixed bank to work on DragonFlight Prepatch

### DIFF
--- a/classes/bag.lua
+++ b/classes/bag.lua
@@ -185,8 +185,7 @@ function Bag:Update()
 
 	if not self.cached then
 		for i, atlas in ipairs(self.FILTER_ICONS) do
-			local active = C_Container and (id > NUM_BAG_SLOTS and C_Container.GetBankBagSlotFlag(id - NUM_BAG_SLOTS, 2^i) or C_Container.GetBagSlotFlag(id, 2^i)) or
-										 GetBagSlotFlag and (id > NUM_BAG_SLOTS and GetBankBagSlotFlag(id - NUM_BAG_SLOTS, i) or GetBagSlotFlag(id, i))
+			local active = C_Container and (id > 0 and C_Container.GetBagSlotFlag(id, 2^i))
 			if active then
 				return self.FilterIcon.Icon:SetAtlas(atlas)
 			end

--- a/classes/bank.lua
+++ b/classes/bank.lua
@@ -9,7 +9,7 @@ Bank.Title = LibStub('AceLocale-3.0'):GetLocale(ADDON).TitleBank
 Bank.Bags = {BANK_CONTAINER}
 
 for slot = 1, NUM_BANKBAGSLOTS do
-	tinsert(Bank.Bags, slot + NUM_BAG_SLOTS)
+	tinsert(Bank.Bags, slot + NUM_BAG_SLOTS+1)
 end
 
 function Bank:OnHide()


### PR DESCRIPTION
Several APIs change in the 10.0.0 prepatch for dragonflight that broke the functionality of the bank. This PR addresses that and fixes the issues caused by:

### bank.lua:
Numbering was off by 1 and accidentally using the characters reagent bag and losing the last bank bag.

### bag.lua:
I may be wrong but I believe that GetBankBagSlotFlag has been removed as it threw nil value errors. The function GetBagSlotFlag works fine with any bag slot code as long as it is >0. An error is thrown is anything less than zero is used. As GetBankBagSlotFlag was removed, and the numbering is simpler, I believe I preserved the logic used in the bag.lua section modified.

This has been testing in game on the 10.0.0 (46340) October 26th patch to be functioning correctly without errors.