### PR TITLE
p2 fixes

### DIFF
--- a/api/events.lua
+++ b/api/events.lua
@@ -37,6 +37,7 @@ end
 
 function Events:BAG_UPDATE(event, bag)
 	self.queue[bag] = true
+  C_Timer.After(0.001, function() self:UpdateBags() end) -- Temporary fix due to missing BAG_UPDATE_DELAYED event
 end
 
 function Events:PLAYERBANKSLOTS_CHANGED()

--- a/classes/item.lua
+++ b/classes/item.lua
@@ -440,7 +440,7 @@ function Item:IsNew()
 end
 
 function Item:IsPaid()
-	return C.IsBattlePayItem(self:GetBag(), self:GetID())
+	return C.IsBattlePayItem
 end
 
 function Item:IsSlot(bag, slot)


### PR DESCRIPTION
few fixes to get combuctor functional


You must install and activate the latest Bagnon, Bagnon_Config, and BagBrother (all 3) in order for the Combuctor bag frame to properly display and be usable. Until proper updates are added to Combuctor, these hacks will do.